### PR TITLE
remove refs to jiro maven repositories

### DIFF
--- a/org.eclipse.xtend.maven.parent/pom.xml
+++ b/org.eclipse.xtend.maven.parent/pom.xml
@@ -34,7 +34,6 @@
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<maven.javadoc.opts></maven.javadoc.opts>
 
-		<upstreamBranch>lb_2052_maven_tycho</upstreamBranch>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 	</properties>
 

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -271,27 +271,6 @@
 			</properties>
 		</profile>
 		<profile>
-			<id>useJenkinsSnapshots</id>
-			<repositories>
-				<repository>
-					<id>lsp4j-from-jenkins</id>
-					<url>${JENKINS_URL}/job/lsp4j/lastStableBuild/artifact/build/maven-repository</url>
-				</repository>
-				<repository>
-					<id>xtext-lib-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-				<repository>
-					<id>xtext-core-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-				<repository>
-					<id>xtext-extras-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-			</repositories>
-		</profile>
-		<profile>
 			<id>useSonatypeSnapshots</id>
 			<repositories>
 				<repository>

--- a/org.eclipse.xtext.maven.parent/pom.xml
+++ b/org.eclipse.xtext.maven.parent/pom.xml
@@ -24,7 +24,6 @@
 		<project.reporting.outputEncoding>ISO-8859-1</project.reporting.outputEncoding>
 		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 		<maven.javadoc.opts></maven.javadoc.opts>
-		<upstreamBranch>lb_2052_maven_tycho</upstreamBranch>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 	</properties>
 

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -8,7 +8,6 @@
 	<version>IT-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<properties>
-		<upstreamBranch>lb_2052_maven_tycho</upstreamBranch>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>11</maven.compiler.source>

--- a/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
+++ b/org.eclipse.xtext.maven.plugin/src/test/resources/it/generate/pom.xml
@@ -135,18 +135,6 @@
 			<url>${JENKINS_URL}/job/lsp4j/lastStableBuild/artifact/build/maven-repository/</url>
 		</repository>
 		<repository>
-			<id>xtext-lib-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-		</repository>
-		<repository>
-			<id>xtext-core-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-		</repository>
-		<repository>
-			<id>xtext-extras-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-		</repository>
-		<repository>
 			<id>central snapshots</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
 		</repository>
@@ -165,18 +153,6 @@
 		<pluginRepository>
 			<id>lsp4j-from-jenkins</id>
 			<url>${JENKINS_URL}/job/lsp4j/lastStableBuild/artifact/build/maven-repository/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>xtext-lib-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>xtext-core-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-		</pluginRepository>
-		<pluginRepository>
-			<id>xtext-extras-from-jenkins</id>
-			<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>central snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
 
 		<root-dir>${basedir}/..</root-dir>
 		<JENKINS_URL>https://ci.eclipse.org/xtext</JENKINS_URL>
-		<upstreamBranch>master</upstreamBranch>
 
 		<target-platform-classifier>xtext-latest</target-platform-classifier>
 

--- a/pom.xml
+++ b/pom.xml
@@ -214,22 +214,6 @@
 					<id>lsp4j-from-jenkins</id>
 					<url>${JENKINS_URL}/job/lsp4j/lastStableBuild/artifact/build/maven-repository</url>
 				</repository>
-				<repository>
-					<id>xtext-lib-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-lib/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-				<repository>
-					<id>xtext-core-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-core/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-				<repository>
-					<id>xtext-extras-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-extras/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
-				<repository>
-					<id>xtext-xtend-from-jenkins</id>
-					<url>${JENKINS_URL}/job/xtext-xtend/job/${upstreamBranch}/lastStableBuild/artifact/build/maven-repository/</url>
-				</repository>
 				<!-- Disable sonatype snapshots -->
 				<repository>
 					<id>sonatype-snapshots</id>


### PR DESCRIPTION
Now that we are self-contained, we must not use Jenkins Maven references anymore for Xtext artifacts (only for LSP4J)

Closes #8 